### PR TITLE
fix to remove use of dangling reference

### DIFF
--- a/cpp-tower-solution/Game.cpp
+++ b/cpp-tower-solution/Game.cpp
@@ -36,7 +36,7 @@ Game::Game() {
 }
 
 void Game::_move(unsigned index1, unsigned index2) {
-  Cube & cube = stacks_[index1].removeTop();
+  Cube cube = stacks_[index1].removeTop();
   stacks_[index2].push_back(cube);
 }
 

--- a/cpp-tower-solution/Stack.cpp
+++ b/cpp-tower-solution/Stack.cpp
@@ -25,8 +25,8 @@ void Stack::push_back(const Cube & cube) {
   cubes_.push_back(cube);
 }
 
-Cube & Stack::removeTop() {
-  Cube & cube = peekTop();
+Cube Stack::removeTop() {
+  Cube cube = peekTop();
   cubes_.pop_back();
   return cube;
 }

--- a/cpp-tower-solution/Stack.h
+++ b/cpp-tower-solution/Stack.h
@@ -14,7 +14,7 @@ using uiuc::Cube;
 class Stack {
   public:
     void push_back(const Cube & cube);
-    Cube & removeTop();
+    Cube removeTop();
     Cube & peekTop();
     unsigned size() const;
 

--- a/cpp-tower-solution2/Game.cpp
+++ b/cpp-tower-solution2/Game.cpp
@@ -37,7 +37,7 @@ Game::Game() {
 
 // Move a Cube from Stack `s1` to Stack `s2`:
 void Game::_moveCube(Stack & s1, Stack & s2) {
-  Cube & cube = s1.removeTop();
+  Cube cube = s1.removeTop();
   s2.push_back(cube);
 }
 

--- a/cpp-tower-solution2/Stack.cpp
+++ b/cpp-tower-solution2/Stack.cpp
@@ -25,8 +25,8 @@ void Stack::push_back(const Cube & cube) {
   cubes_.push_back(cube);
 }
 
-Cube & Stack::removeTop() {
-  Cube & cube = peekTop();
+Cube Stack::removeTop() {
+  Cube cube = peekTop();
   cubes_.pop_back();
   return cube;
 }

--- a/cpp-tower-solution2/Stack.h
+++ b/cpp-tower-solution2/Stack.h
@@ -14,7 +14,7 @@ using uiuc::Cube;
 class Stack {
   public:
     void push_back(const Cube & cube);
-    Cube & removeTop();
+    Cube removeTop();
     Cube & peekTop();
     unsigned size() const;
 

--- a/cpp-tower/Stack.cpp
+++ b/cpp-tower/Stack.cpp
@@ -25,8 +25,8 @@ void Stack::push_back(const Cube & cube) {
   cubes_.push_back(cube);
 }
 
-Cube & Stack::removeTop() {
-  Cube & cube = peekTop();
+Cube Stack::removeTop() {
+  Cube cube = peekTop();
   cubes_.pop_back();
   return cube;
 }

--- a/cpp-tower/Stack.h
+++ b/cpp-tower/Stack.h
@@ -14,7 +14,7 @@ using uiuc::Cube;
 class Stack {
   public:
     void push_back(const Cube & cube);
-    Cube & removeTop();
+    Cube removeTop();
     Cube & peekTop();
     unsigned size() const;
 


### PR DESCRIPTION
The examples still compile and run with the intended behavior. (The stack address themselves are shown in the diagnostic output, but I don't think it was ever intended for the Cubes themselves to use move semantics with the same references. Everything's fine with pass by value for the Cubes.)

This addresses https://github.com/wadefagen/coursera/issues/4