### PR TITLE
expanding linked-memory with fixes for cross-compiler standards...

### DIFF
--- a/linked-memory/List.h
+++ b/linked-memory/List.h
@@ -5,6 +5,13 @@
  *   Wade Fagen-Ulmschneider <waf@illinois.edu>
  */
 
+// Note: When you define functions within the class definition, you can
+// assume that all member variable definitions in the class are in scope,
+// regardless of where they are defined. So, we can refer to head_ in the
+// List constructor near the top, before the line where head_ is defined.
+// More info:
+// https://stackoverflow.com/questions/13094898/do-class-functions-variables-have-to-be-declared-before-being-used
+
 #pragma once
 
 template <typename T>
@@ -12,6 +19,30 @@ class List {
   public:
     const T & operator[](unsigned index);
     void insertAtFront(const T & data);
+
+    // We define this constructor to make sure that head_ is null-initialized.
+    List() : head_(nullptr) { }
+
+    // We define a destructor to delete the memory allocated for the ListNode
+    // objects when the List is destroyed.
+    ~List() {
+      // We'll walk through from the head.
+      ListNode *thru = head_;
+      while (thru != nullptr) {
+        // Copy the address that the "thru" pointer has currently.
+        ListNode* toDelete = thru;
+        // Step the pointer to the "next" pointer of the current node.
+        thru = thru->next;
+        // Now, finally, we can delete the toDelete pointer. We could not
+        // delete it before we stepped away from it above, because we needed
+        // the next pointer information first.
+        delete toDelete;
+        // We don't strictly need to set toDelete to nullptr here because
+        // it goes out of scope immediately after, but remember that you
+        // should generally do this after deleting a pointer:
+        toDelete = nullptr;
+      }
+    }
 
   private:
     class ListNode {
@@ -26,4 +57,6 @@ class List {
     ListNode* _find(const T & data);
 };
 
+// Finish including the rest of the header from the additional header file.
+// This is just done to spread out our writing among more manageable files.
 #include "List.hpp"

--- a/linked-memory/List.hpp
+++ b/linked-memory/List.hpp
@@ -5,6 +5,9 @@
  *   Wade Fagen-Ulmschneider <waf@illinois.edu>
  */
 
+// Redundantly make sure theat List.h is included. Since List.h is written
+// to include this file, we won't need to explicitly include List.hpp in
+// the main.cpp file.
 #include "List.h"
 
 template <typename T>
@@ -46,6 +49,7 @@ typename List<T>::ListNode *List<T>::_find(const T & data) {
   ListNode *thru = head_;
   while (thru != nullptr) {
     if (thru->data == data) { return thru; }
+    thru = thru->next;
   }
 
   return nullptr;  

--- a/linked-memory/main.cpp
+++ b/linked-memory/main.cpp
@@ -11,12 +11,18 @@
 int main() {
   List<int> list;
 
+  // We'll be able to store const references to these objects in the List
+  // because these constants on the stack exist in the same function scope
+  // that lasts until the end of main().
+  const int item_a = 3;
+  const int item_b = 30;
+
   std::cout << "Inserting element 3 at front..." << std::endl; 
-  list.insertAtFront(3);
+  list.insertAtFront(item_a);
   std::cout << "list[0]: " << list[0] << std::endl;
 
   std::cout << "Inserting element 30 at front..." << std::endl; 
-  list.insertAtFront(30);
+  list.insertAtFront(item_b);
   std::cout << "list[0]: " << list[0] << std::endl;
   std::cout << "list[1]: " << list[1] << std::endl;
 


### PR DESCRIPTION
...and some other things. Added a constructor to make sure the head pointer is null-initialized (standard doesn't guarantee this, although clang seems to do it); added a destructor; added some notes explaining why it's okay to refer to things before they're defined in the class definition, and why the ".hpp" include is used here; fixed the implementation of _find to iterate through; defined some named ints in main for the list to obtain const refs to, because the standard doesn't let us store const refs to int literals. (It works in clang, breaks in GCC.)