### PR TITLE
fixed compile error for compilers in which long is implemented as 4 bytes instead of 8 bytes

### DIFF
--- a/array/ex2/main.cpp
+++ b/array/ex2/main.cpp
@@ -16,7 +16,7 @@ int main() {
 
   // Using pointer arithmetic, ask the computer to calculate
   // the offset from the beginning of the array to [2]:
-  int offset = (long)&(values[2]) - (long)&(values[0]);
+  int offset = (long long)&(values[2]) - (long long)&(values[0]);
   std::cout << offset << std::endl;
 
   return 0;

--- a/array/ex3/main.cpp
+++ b/array/ex3/main.cpp
@@ -19,7 +19,7 @@ int main() {
 
   // Using pointer arithmetic, ask the computer to calculate
   // the offset from the beginning of the array to [2]:
-  int offset = (long)&(cubes[2]) - (long)&(cubes[0]);
+  int offset = (long long)&(cubes[2]) - (long long)&(cubes[0]);
   std::cout << offset << std::endl;
 
   return 0;

--- a/array/ex4/main.cpp
+++ b/array/ex4/main.cpp
@@ -22,7 +22,7 @@ int main() {
 
   // Using pointer arithmetic, ask the computer to calculate
   // the offset from the beginning of the array to [2]:
-  int offset = (long)&(cubes[2]) - (long)&(cubes[0]);
+  int offset = (long long)&(cubes[2]) - (long long)&(cubes[0]);
   std::cout << "Memory separation: " << offset << std::endl;
 
   // Find a specific `target` cube in the array:


### PR DESCRIPTION
I got this compile error when I make the array\ex3 folder:
"
g++ -std=c++14 -O0 -pedantic -Wall  -Wfatal-errors -Wextra  -MMD -MP -g -c  main.cpp -o .objs/main.o
main.cpp: In function 'int main()':
main.cpp:26:16: error: cast from 'uiuc::Cube*' to 'long int' loses precision [-fpermissive]
   26 |   int offset = (long)&(cubes[2]) - (long)&(cubes[0]);
      |                ^~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
make: *** [../../_make/generic.mk:62: .objs/main.o] Error 1
"

I figured it is because a long is at least 4 bytes and a "long long" is at least 8 bytes. To properly cast the pointer without losing precision for compilers that implement long with 4 bytes, a "long long" should be used.