### PR TITLE
Add devcontainer.json

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:22.04
+
+RUN apt update && apt upgrade -y
+RUN apt install -y gcc g++ clang make gdb valgrind graphviz imagemagick git zip unzip

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:22.04
+# MINSIGSTKSZ usage requires <2.34
+FROM --platform=amd64 ubuntu:20.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt update && apt upgrade -y
 RUN apt install -y gcc g++ clang make gdb valgrind graphviz imagemagick git zip unzip

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/cpp
+{
+	"name": "C++",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
Hi,

Thanks a ton for this course!

I've added a devcontainer.json spec to make it easier for other students to get set up.
The key thing is to use Ubuntu 20.04 since some code unfortunately doesn't work with later versions of glibc.

This spec is also supported by more open source projects like [devpod](https://devpod.sh/), which can also use AWS as a provider, though I think even just the Dockerfile will already be helpful for those not inclined to use codespaces.